### PR TITLE
Fix inconsistent sorting of department scores

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -1443,3 +1443,24 @@ if (!function_exists('getPoliceFundingChart')) {
         ));
     }
 }
+
+/**
+ * Sort Grades
+ *
+ * @param object $grades
+ *
+ * @return object
+ */
+if (!function_exists('sortGrades')) {
+    function sortGrades($grades) {
+        if (!is_array($grades)) {
+            return array();
+        }
+
+        usort($grades, function($a, $b) {
+            return $a['overall_score'] > $b['overall_score'];
+        });
+
+        return $grades;
+    }
+}

--- a/app/View/Components/Partial/Grades.php
+++ b/app/View/Components/Partial/Grades.php
@@ -16,8 +16,8 @@ class Grades extends Component
      */
     public function __construct($grades = [], $type = 'police-department')
     {
-        // Cap Grades Report to worst 500
-        $this->grades = array_slice($grades, 0, 500);
+        // Cap Grades Report to worst 1000
+        $this->grades = array_slice($grades, 0, 1000);
         $this->type = $type;
     }
 

--- a/app/View/Components/Partial/Grades.php
+++ b/app/View/Components/Partial/Grades.php
@@ -9,6 +9,8 @@ class Grades extends Component
     public $grades;
     public $type;
 
+    protected $maxGrades = 1000;
+
     /**
      * Create a new component instance.
      *
@@ -16,8 +18,7 @@ class Grades extends Component
      */
     public function __construct($grades = [], $type = 'police-department')
     {
-        // Cap Grades Report to worst 1000
-        $this->grades = array_slice($grades, 0, 1000);
+        $this->grades = array_slice($grades, 0, $this->maxGrades);
         $this->type = $type;
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -142,15 +142,10 @@ Route::get('/{state}', function ($state) {
     $total = getStateTotal($states, $state);
     $location = $scorecard['agency']['slug'];
 
-    // Sort Grades
-    usort($grades, function($a, $b) {
-        return $a['overall_score'] > $b['overall_score'];
-    });
-
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",
         'description' => "Get the facts about police violence and accountability in {$scorecard['geo']['state']['name']}. Evaluate each department and hold them accountable at PoliceScorecard.org",
-        'grades' => $grades,
+        'grades' => sortGrades($grades),
         'location' => $location,
         'scorecard' => $scorecard,
         'state' => $state,
@@ -170,15 +165,10 @@ Route::get('/{state}/{type}', function ($state, $type) {
     $total = getStateTotal($states, $state);
     $location = $scorecard['agency']['slug'];
 
-    // Sort Grades
-    usort($grades, function($a, $b) {
-        return $a['overall_score'] > $b['overall_score'];
-    });
-
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",
         'description' => "Get the facts about police violence and accountability in {$scorecard['geo']['state']['name']}. Evaluate each department and hold them accountable at PoliceScorecard.org",
-        'grades' => $grades,
+        'grades' => sortGrades($grades),
         'location' => $location,
         'scorecard' => $scorecard,
         'state' => $state,
@@ -197,15 +187,10 @@ Route::get('/{state}/{type}/{location}', function ($state, $type, $location) {
     $states = $api->fetchStates();
     $total = getStateTotal($states, $state);
 
-    // Sort Grades
-    usort($grades, function($a, $b) {
-        return $a['overall_score'] > $b['overall_score'];
-    });
-
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",
         'description' => "Get the facts about police violence and accountability in {$scorecard['geo']['state']['name']}. Evaluate each department and hold them accountable at PoliceScorecard.org",
-        'grades' => $grades,
+        'grades' => sortGrades($grades),
         'location' => $location,
         'scorecard' => $scorecard,
         'state' => $state,

--- a/routes/web.php
+++ b/routes/web.php
@@ -142,6 +142,11 @@ Route::get('/{state}', function ($state) {
     $total = getStateTotal($states, $state);
     $location = $scorecard['agency']['slug'];
 
+    // Sort Grades
+    usort($grades, function($a, $b) {
+        return $a['overall_score'] > $b['overall_score'];
+    });
+
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",
         'description' => "Get the facts about police violence and accountability in {$scorecard['geo']['state']['name']}. Evaluate each department and hold them accountable at PoliceScorecard.org",
@@ -165,6 +170,11 @@ Route::get('/{state}/{type}', function ($state, $type) {
     $total = getStateTotal($states, $state);
     $location = $scorecard['agency']['slug'];
 
+    // Sort Grades
+    usort($grades, function($a, $b) {
+        return $a['overall_score'] > $b['overall_score'];
+    });
+
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",
         'description' => "Get the facts about police violence and accountability in {$scorecard['geo']['state']['name']}. Evaluate each department and hold them accountable at PoliceScorecard.org",
@@ -186,6 +196,11 @@ Route::get('/{state}/{type}/{location}', function ($state, $type, $location) {
     $stateData = $api->fetchStateData($state);
     $states = $api->fetchStates();
     $total = getStateTotal($states, $state);
+
+    // Sort Grades
+    usort($grades, function($a, $b) {
+        return $a['overall_score'] > $b['overall_score'];
+    });
 
     return view('report', [
         'title' => "Police Scorecard: {$scorecard['geo']['state']['name']}",


### PR DESCRIPTION
Overview:
---

Also updated max departments from 500 to 1,000.

Reviewer:
---

> Where should the reviewer start? How to Test? Background Context? etc ( required )

Home page sorting was correct, but report pages had the order backwards.

Checklist:
---

> I have tested each of the following, and they work as expected: ( required )

- [X] Meets [Contributing Guide](https://github.com/campaignzero/police-scorecard/blob/develop/.github/CONTRIBUTING.md) Requirements
- [X] Pulled in the Latest Code from the `develop` branch
- [X] Works on a Desktop / Laptop Device
- [X] Works on a Mobile Device
- [X] `npm test` Does Not Generate Errors

Documentation:
---

> Screenshots, Attachments, Linked GitHub Issues, etc ( optional )

Fixes #4 & #8 

#### What GIF best describes this PR or how it makes you feel?

> Drag & Drop Something Fun Here ( optional )

![that_a_boy](https://user-images.githubusercontent.com/508411/92560619-b6fbb780-f240-11ea-9cc2-672fda69913c.gif)
