### PR TITLE
Fix issue with Use of Force Complaints not showing up

### DIFF
--- a/resources/views/components/partial/police-accountability/chart-use-of-force.blade.php
+++ b/resources/views/components/partial/police-accountability/chart-use-of-force.blade.php
@@ -11,7 +11,7 @@
     <p>
         {{ num($scorecard['police_accountability']['use_of_force_complaints_reported']) }} Reported
 
-        @if($scorecard['report']['percent_use_of_force_complaints_sustained'])
+        @if(isset($scorecard['report']['percent_use_of_force_complaints_sustained']))
         <span class="divider">&nbsp;|&nbsp;</span>
         {{ num($scorecard['report']['percent_use_of_force_complaints_sustained'], 0, '%') }} Ruled in Favor of Civilians
         @endif
@@ -24,7 +24,7 @@
     <p>
         {{ num($scorecard['police_accountability']['use_of_force_complaints_reported']) }} Reported
 
-        @if($scorecard['report']['percent_use_of_force_complaints_sustained'])
+        @if(isset($scorecard['report']['percent_use_of_force_complaints_sustained']))
         <span class="divider">&nbsp;|&nbsp;</span>
         {{ num($scorecard['report']['percent_use_of_force_complaints_sustained'], 0, '%') }} Ruled in Favor of Civilians
         @endif


### PR DESCRIPTION
Overview:
---

User of Force Complaints Sustained was not showing up, even though it had a value of zero.

Reviewer:
---

> Where should the reviewer start? How to Test? Background Context? etc ( required )

Conditional logic here was treating a `0` as `false`.  Only time we are supposed to hide this is if the value is empty ( not zero ).

Checklist:
---

> I have tested each of the following, and they work as expected: ( required )

- [X] Meets [Contributing Guide](https://github.com/campaignzero/police-scorecard/blob/develop/.github/CONTRIBUTING.md) Requirements
- [X] Pulled in the Latest Code from the `develop` branch
- [X] Works on a Desktop / Laptop Device
- [X] Works on a Mobile Device
- [X] `npm test` Does Not Generate Errors

Documentation:
---

> Screenshots, Attachments, Linked GitHub Issues, etc ( optional )

Fixes #9 

![screenshot 2020-09-09 at 2 23 19 AM](https://user-images.githubusercontent.com/508411/92562302-bca6cc80-f243-11ea-8baf-553d38a30d0b.png)

#### What GIF best describes this PR or how it makes you feel?

> Drag & Drop Something Fun Here ( optional )

![yup](https://user-images.githubusercontent.com/508411/92562345-d1836000-f243-11ea-94c6-9adf913ede64.gif)
